### PR TITLE
GH-5 - Upgraded packages to latest version 1.1.5

### DIFF
--- a/nvm.portable/nvm.nuspec
+++ b/nvm.portable/nvm.nuspec
@@ -5,7 +5,7 @@
     <!-- Read this before publishing packages to chocolatey.org: https://github.com/chocolatey/chocolatey/wiki/CreatePackages -->
     <id>nvm.portable</id>
     <title>NVM (Portable)</title>
-    <version>1.1.1</version>
+    <version>1.1.5</version>
     <authors>coreybutler</authors>
     <owners>Ariel Jannai, Ethan Spoelstra</owners>
     <summary>A node.js version management utility for Windows.</summary>

--- a/nvm.portable/tools/chocolateyinstall.ps1
+++ b/nvm.portable/tools/chocolateyinstall.ps1
@@ -2,7 +2,7 @@
 $ErrorActionPreference = "Stop"
 
 $packageName= 'nvm'
-$url        = "https://github.com/coreybutler/nvm-windows/releases/download/1.1.1/nvm-noinstall.zip"
+$url        = "https://github.com/coreybutler/nvm-windows/releases/download/1.1.5/nvm-noinstall.zip"
 
 $nodePath = "$env:SystemDrive\Program Files\nodejs"
 # Install nvm to its own directory, not in the chocolatey lib folder
@@ -16,7 +16,7 @@ $packageArgs = @{
   unzipLocation = $nvmPath
   url           = $url
 
-  checksum      = 'D2AC6DD3859B463A4D9249680E3A0BAB104652CBB63987C262767A1F8E058B4AA07405668732E33D06907AAA76208FAFFC7DE85398C5A0A36A90D9E484C06068'
+  checksum      = 'A2BFB76C740692ABCDE7B3A9E60DC8A9CE475C8DBDE3938FD929B76E7067ED60B716E6279BB158036DC613C6928FE9AF809F4F437302D9D6DCB325A993F359B9'
   checksumType  = 'sha512'
 }
 Install-ChocolateyZipPackage @packageArgs

--- a/nvm/nvm.nuspec
+++ b/nvm/nvm.nuspec
@@ -5,7 +5,7 @@
     <!-- Read this before publishing packages to chocolatey.org: https://github.com/chocolatey/chocolatey/wiki/CreatePackages -->
     <id>nvm</id>
     <title>NVM</title>
-    <version>1.1.1</version>
+    <version>1.1.5</version>
     <authors>coreybutler</authors>
     <owners>Ariel Jannai, Ethan Spoelstra</owners>
     <summary>A node.js version management utility for Windows.</summary>
@@ -19,7 +19,7 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <iconUrl>http://devstickers.com/assets/img/cat/nodejs.png</iconUrl>
     <dependencies>
-      <dependency id="nvm.portable" version="1.1.0" />
+      <dependency id="nvm.portable" version="1.1.5" />
     </dependencies>
     <!-- <releaseNotes>__REPLACE_OR_REMOVE__MarkDown_Okay</releaseNotes> -->
     <!--<provides></provides>-->


### PR DESCRIPTION
Fixes #5 by updating packages to the latest release 1.1.5

* Updated nvm.portable nuspec version to 1.1.5 and chocolateyinstall.ps1 with link to latest install artifact and updated the checksum to correspond.
* Updated nvm nuspec version to 1.1.5.