### PR TITLE
Added InstallationPath and NodePath params to choco install

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -8,6 +8,12 @@ Basically, following the [manual installation guide](https://github.com/coreybut
 * Creating `NVM_HOME` and `NVM_SYMLINK` environment variables
 * Adding the nvm environment variables to the path
 
+### Setting the NVM Installation Path
+To manually set the NVM installation path you need to pass the required `InstallationPath` to the `choco install` command, e.g.:
+```
+choco install nvm --params "/InstallationPath=""c:\nvm"""
+```
+
 ## Uninstallation process
 * Calling `nvm off` to unlink the nodejs install folder from program files.
 * Removing the nvm folder recursively with force
@@ -16,6 +22,6 @@ Basically, following the [manual installation guide](https://github.com/coreybut
 ## TODO
 - [X] Remove the environment variables from path on uninstall.
 - [X] Create script for updating (save settings.txt and not to overwrite it).
-- [ ] Add package parameters to choose the install folders.
+- [X] Add package parameters to choose the install folders.
 - [ ] Allow installing specific nodejs version with the installation.
 - [ ] Option to uninstall nvm but keep the files.

--- a/nvm.portable/tools/chocolateyinstall.ps1
+++ b/nvm.portable/tools/chocolateyinstall.ps1
@@ -4,16 +4,20 @@ $ErrorActionPreference = "Stop"
 $packageName= 'nvm'
 $url        = "https://github.com/coreybutler/nvm-windows/releases/download/1.1.5/nvm-noinstall.zip"
 
-$nodePath = "$env:SystemDrive\Program Files\nodejs"
+# Get Package Parameters
+$pp = Get-PackageParameters
+
 # Install nvm to its own directory, not in the chocolatey lib folder
 # If requesting per user install use $env:APPDATA else $env:ProgramData
-$nvmPath = Join-Path $env:ProgramData $packageName
+if (!$pp.InstallationPath) { $pp.InstallationPath = Join-Path $env:ProgramData $packageName }
+if (!$pp.NodePath) { $pp.NodePath = "$env:SystemDrive\Program Files\nodejs" }
+
 $OsBits = Get-ProcessorBits
-$NvmSettingsFile = Join-Path $nvmPath "settings.txt"
+$NvmSettingsFile = Join-Path $pp.InstallationPath "settings.txt"
 
 $packageArgs = @{
   packageName   = $packageName
-  unzipLocation = $nvmPath
+  unzipLocation = $pp.InstallationPath
   url           = $url
 
   checksum      = 'A2BFB76C740692ABCDE7B3A9E60DC8A9CE475C8DBDE3938FD929B76E7067ED60B716E6279BB158036DC613C6928FE9AF809F4F437302D9D6DCB325A993F359B9'
@@ -22,7 +26,7 @@ $packageArgs = @{
 Install-ChocolateyZipPackage @packageArgs
 
 #New-Item "$NvmSettingsFile" -type file -force -value `
-# $("root: $nvmPath `r`npath: $nodePath `r`narch: $OsBits`r`nproxy: none");
+# $("root: $pp.InstallationPath `r`npath: $pp.NodePath `r`narch: $OsBits`r`nproxy: none");
 
 # This pattern will be easier to maintain if new settings are added
 # If existing settings file, read and create dictionary of values
@@ -34,8 +38,8 @@ if (Test-Path $NvmSettingsFile) {
     $NvmSettingsDict.GetEnumerator() | % { "$($_.Name): $($_.Value)" } | Write-Verbose
 }
 # only set values if not present or missing from existing settings
-if (!($NvmSettingsDict['root'])) { $NvmSettingsDict['root'] = $nvmPath }
-if (!($NvmSettingsDict['path'])) { $NvmSettingsDict['path'] = $nodePath }
+if (!($NvmSettingsDict['root'])) { $NvmSettingsDict['root'] = $pp.InstallationPath }
+if (!($NvmSettingsDict['path'])) { $NvmSettingsDict['path'] = $pp.NodePath }
 if (!($NvmSettingsDict['arch'])) { $NvmSettingsDict['arch'] = $OsBits }
 if (!($NvmSettingsDict['proxy'])) { $NvmSettingsDict['proxy'] = "none" }
 
@@ -46,7 +50,7 @@ $NvmSettingsDict.GetEnumerator() | % { "$($_.Name): $($_.Value)" } | Out-File "$
 
 # If you don't install to the toolsDir Chocolatey won't create a shim
 # This would avoid creating an nvm.exe shim in the $chocolateyRoot\bin folder that is in the path
-#$files = get-childitem $nvmPath -include *.exe -recurse
+#$files = get-childitem $pp.InstallationPath -include *.exe -recurse
 
 #foreach ($file in $files) {
 #  #generate an ignore file
@@ -54,8 +58,8 @@ $NvmSettingsDict.GetEnumerator() | % { "$($_.Name): $($_.Value)" } | Out-File "$
 #}
 
 # Could install per user variables if not running node as a service or other users
-Install-ChocolateyEnvironmentVariable -VariableName "NVM_HOME" -VariableValue "$nvmPath" -VariableType Machine;
-Install-ChocolateyEnvironmentVariable -VariableName "NVM_SYMLINK" -VariableValue "$nodePath" -VariableType Machine;
+Install-ChocolateyEnvironmentVariable -VariableName "NVM_HOME" -VariableValue "$($pp.InstallationPath)" -VariableType Machine;
+Install-ChocolateyEnvironmentVariable -VariableName "NVM_SYMLINK" -VariableValue "$($pp.NodePath)" -VariableType Machine;
 
 # Adding NVM_HOME to the path isn't required if you use the shim, it IS required if you don't use the shim (ie install outside of $toolsDir or ignore above)
 # Having it on the PATH twice could be confusing even though it is the "same" file


### PR DESCRIPTION
To manually set the NVM installation path you need to pass the required `InstallationPath` to the `choco install` command, e.g.:
```
choco install nvm --params "/InstallationPath=""c:\nvm"""
```
